### PR TITLE
Fix: ドキュメント新規作成時に、前回のキャッシュが引き継がれる問題を修正

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -29,7 +29,6 @@ function MyApp({ Component, pageProps }: AppProps) {
   const updateDocumentList = () => {
     setDocumentList(RESTDocument.getList());
   };
-  console.log(tagList);
 
   const props = {
     companyList,

--- a/frontend/src/pages/edit/index.tsx
+++ b/frontend/src/pages/edit/index.tsx
@@ -9,15 +9,19 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import TermCreateSelect from "components/TermCreateSelect";
 import { defaultDocument } from "consts/default-value";
-import { Company, DocumentHistory, PageProps, Tag } from "interfaces/interfaces";
+import {
+  Company,
+  Document,
+  DocumentHistory,
+  PageProps,
+  Tag,
+} from "interfaces/interfaces";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import styles from "styles/Edit.module.scss";
 import { RESTCompany, RESTDocument, RESTHistory, RESTTag } from "utils/REST";
 import { genRandomId } from "utils/utils";
-
-let document = defaultDocument;
 
 let preEditUnix = 0;
 let viewingHistoryIdx = 0;
@@ -44,22 +48,26 @@ const Home: NextPage<PageProps> = (props) => {
     "tagList"
   );
   const [canEdit, setCanEdit] = useState<boolean>(true);
+  const [document, setDocument] = useState<Document>({ ...defaultDocument });
 
   // 文書読み込み
   useEffect(() => {
     if (!documentId) return;
-    document = RESTDocument.get(documentId as string) || document;
-    if (document.id) {
+    const documentToLoad = RESTDocument.get(documentId as string) || document;
+    if (documentToLoad.id) {
       // 存在した場合
-      editHistory[viewingHistoryIdx] = document.text;
-      setCompany(RESTCompany.get(document.companyId));
-      setTag(RESTTag.get(document.tagId));
-      setDocumentText(document.text);
-      documentHistory = RESTHistory.getList().filter((v) => v.documentId === document.id);
+      editHistory[viewingHistoryIdx] = documentToLoad.text;
+      setCompany(RESTCompany.get(documentToLoad.companyId));
+      setTag(RESTTag.get(documentToLoad.tagId));
+      setDocumentText(documentToLoad.text);
+      documentHistory = RESTHistory.getList().filter(
+        (v) => v.documentId === documentToLoad.id
+      );
     } else {
       // 存在しない場合
-      document.id = documentId as string;
+      documentToLoad.id = documentId as string;
     }
+    setDocument(documentToLoad);
   }, [documentId]);
 
   const onClickDelete = () => {
@@ -144,7 +152,7 @@ const Home: NextPage<PageProps> = (props) => {
                     .map((v) => {
                       return (
                         <li
-                          key={v.tagId}
+                          key={v.id}
                           className={styles.tag}
                           onMouseOver={() => {
                             setDocumentText(v.text);

--- a/frontend/src/pages/list.tsx
+++ b/frontend/src/pages/list.tsx
@@ -4,6 +4,7 @@ import EditItemList from "components/EditItemList";
 import TermSelect from "components/TermSelect";
 import { Company, Document, PageProps, Tag } from "interfaces/interfaces";
 import type { NextPage } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 import styles from "styles/List.module.scss";
@@ -20,11 +21,13 @@ const DocumentTile: React.VFC<{
   const attachedTag = RESTTag.get(props.document.tagId, props.tagList);
 
   return (
-    <a className={styles.document} href={"/edit/" + props.document.id}>
-      <p className={styles.tec}>{attachedCompany?.name || "企業未選択"}</p>
-      <p className={styles.tec}>{attachedTag?.name || "項目未選択"}</p>
-      <p>{props.document.text}</p>
-    </a>
+    <Link href={{ pathname: "/edit", query: { documentId: props.document.id } }}>
+      <a className={styles.document}>
+        <p className={styles.tec}>{attachedCompany?.name || "企業未選択"}</p>
+        <p className={styles.tec}>{attachedTag?.name || "項目未選択"}</p>
+        <p>{props.document.text}</p>
+      </a>
+    </Link>
   );
 };
 

--- a/frontend/src/pages/list.tsx
+++ b/frontend/src/pages/list.tsx
@@ -144,7 +144,7 @@ const List: NextPage<PageProps> = (props) => {
           className={styles.new_document}
           onClick={() => {
             const randomId = genRandomId();
-            router.push("/edit/" + randomId);
+            router.push({ pathname: "/edit", query: { documentId: randomId } });
           }}
         >
           <div className={styles.font_awesome_btn}>


### PR DESCRIPTION
## 原因
* `defaultDocument`の参照が渡されたことで書き換わってしまうこと

## 解決方法
* スプレット構文を利用してコピー

## 他修正点
* クエリをURLクエリパラメータとして渡すように変更